### PR TITLE
TS-142 - Remove WFH from update holiday options if pending or rejected

### DIFF
--- a/src/components/BookingModal/BookingForm/container.js
+++ b/src/components/BookingModal/BookingForm/container.js
@@ -197,11 +197,31 @@ const Container = Wrapped =>
     };
 
     getOptions = () => {
-      const options = [
+      const { booking, isEventBeingUpdated } = this.props;
+      const {
+        eventType: { eventTypeId },
+        eventStatus: { eventStatusId },
+      } = booking;
+      const isWFH = eventTypeId === eventTypes.WFH;
+
+      let options = [
         { value: 1, displayValue: 'Annual Leave' },
         { value: 2, displayValue: 'Working from home' },
       ];
-      this.state.workingFromHomeBooking ? options.shift() : '';
+
+      if (isEventBeingUpdated) {
+        if (isWFH) {
+          options = options.filter(option => option.value === eventTypes.WFH);
+        } else if (
+          eventStatusId === holidayStatus.PENDING ||
+          eventStatusId === holidayStatus.REJECTED
+        ) {
+          options = options.filter(
+            option => option.value === eventTypes.ANNUAL_LEAVE
+          );
+        }
+      }
+
       return options;
     };
 


### PR DESCRIPTION
- Removes WFH from the holiday type options when updating a holiday. 
- Solidifies some older code that used unshift to remove an option (not good if option order ever changed)

![image](https://user-images.githubusercontent.com/39301552/48197350-7170b980-e34d-11e8-8cfe-34494fe46b25.png)
