### PR TITLE
A couple of styling changes

### DIFF
--- a/src/components/AdminDashboard/styled.js
+++ b/src/components/AdminDashboard/styled.js
@@ -23,7 +23,7 @@ export const InnerLayout = styled.div`
           :hover {
             color: white;
             background: ${({ theme }) => theme.colours.unoBlue};
-            border: 0;
+            border-color: ${({ theme }) => theme.colours.unoBlue};
           }
         }
       }
@@ -36,12 +36,10 @@ export const InnerLayout = styled.div`
 
     > div {
       padding: 0px;
-      margin: 15px;
+      margin-right: 50px;
+      margin-bottom: 25px;
       display: flex;
       flex-direction: column;
-      box-shadow: 0px 2px 10px 0px rgba(0,0,0,0.25);
-      border: 1px solid ${({ theme }) => theme.colours.grey};
-      border-radius: 4px;
       width: 400px;
     }
   }

--- a/src/pages/TeamDashboard/TeamSidebar/styled.js
+++ b/src/pages/TeamDashboard/TeamSidebar/styled.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const ContainerStyle = styled.div`
-  min-width: 200px;
+  min-width: 250px;
   height: 100vh;
   padding: 20px 10px 10px 10px;
   background-color: ${props => props.theme.colours.lightgrey};


### PR DESCRIPTION
- On the team page, the minimum width of the sidebar is slightly increased to minimise cases of text wrapping.
- On the admin dashboard, the "card" styling is removed to reduce the visual complexity of the page.

![chrome_2019-02-21_15-21-01](https://user-images.githubusercontent.com/39301552/53186091-3e022400-35f8-11e9-9b54-41319b6dc32e.png)
