### PR TITLE
GUI - undefined error message when a client has no team

### DIFF
--- a/src/components/ViewTeams/container.js
+++ b/src/components/ViewTeams/container.js
@@ -20,7 +20,7 @@ export default Wrapped =>
     teamSearch = clientId => {
       getTeamsFromClient(clientId)
         .then(response => {
-          const teams = response.data;
+          const teams = response.data || [];
           this.setState({ teams });
         })
         .catch(error =>


### PR DESCRIPTION
## Relevant Issues

https://trello.com/c/pSlq9Cd3/11-gui-undefined-error-message-when-a-client-has-no-team

## Major Changes Made

* Error caused by trying to pull down a list of teams from a client when now exist.
* Backend code updated here - https://github.com/UnosquareBelfast/admin-backend/pull/59
* getTeamsFromClient now handles response and returns either the teams associated with the client, or an empty array.

## AC List

GUI - undefined error message when a client has no team

Steps to reproduce:

Add a client.

Navigate to the 'View team' screen
Select your client from the 'Pick a client' dropdown
Bug: Modal is displayed saying "Could not get teams: Cannot read property 'data of undefined'

Expected Result:
1. Add a client.
2. Navigate to the 'View team' screen
3. Select your client from the 'Pick a client' dropdown

Modal is displayed but the error message is more meaningful

