### PR TITLE
Dashboard - next month not shown by default

### DIFF
--- a/src/pages/Dashboard/styled.js
+++ b/src/pages/Dashboard/styled.js
@@ -75,9 +75,11 @@ export const InnerLayout = styled.div`
   }
 
   .rbc-off-range-bg {
-    background: ${props => props.theme.colours.lightgrey};
-    cursor: not-allowed;
-  }
+    background: ${props => props.theme.colours.lightgrey} !important;
+		cursor: not-allowed;
+		position: relative;
+		z-index: 5;
+	}
 
   .rbc-off-range a {
     color: ${props => props.theme.colours.grey} !important;
@@ -92,7 +94,7 @@ export const InnerLayout = styled.div`
   }
 
   .rbc-today {
-    background-color: ${props => props.theme.colours.lightBlue};
+		background-color: ${props => props.theme.colours.lightBlue};
   }
 `;
 

--- a/src/pages/Dashboard/styled.js
+++ b/src/pages/Dashboard/styled.js
@@ -76,10 +76,10 @@ export const InnerLayout = styled.div`
 
   .rbc-off-range-bg {
     background: ${props => props.theme.colours.lightgrey} !important;
-		cursor: not-allowed;
-		position: relative;
-		z-index: 5;
-	}
+    cursor: not-allowed;
+    position: relative;
+    z-index: 5;
+  }
 
   .rbc-off-range a {
     color: ${props => props.theme.colours.grey} !important;
@@ -94,7 +94,7 @@ export const InnerLayout = styled.div`
   }
 
   .rbc-today {
-		background-color: ${props => props.theme.colours.lightBlue};
+    background-color: ${props => props.theme.colours.lightBlue};
   }
 `;
 


### PR DESCRIPTION
## Relevant Issues

https://trello.com/c/Ty3fmCHb/20-dashboard-next-month-not-shown-by-default

## Major Changes Made

* Added css z-index to hide any events displaying in the next or previous month. 
* Also prevented current day styling from displaying if in next or previous month

## AC List

If next months days are visible in the calendar, they should indicate when an event is booked.
