### PR TITLE
Working from home modal window displaying "Holiday Message" label

### DIFF
--- a/src/components/Messaging/index.js
+++ b/src/components/Messaging/index.js
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react';
 import { PropTypes as PT } from 'prop-types';
+import eventTypes, { typeText } from '../../constants/eventTypes';
+
 import container from './container';
 import {
   StyleContainer,
@@ -81,7 +83,9 @@ const Messaging = ({
   updateMessage,
   currentMessage,
   hideNav,
+  title,
 }) => {
+
   return (
     <StyleContainer>
       <div style={{ position: 'relative' }}>
@@ -93,7 +97,7 @@ const Messaging = ({
             />
           </div>
         )}
-        {!hideNav && <h2>Holiday Messages</h2>}
+        {!hideNav && <h2>{ `${title} Messages` }</h2>}
         <ChatBox>{renderMessages(messages)}</ChatBox>
         <div className="replyBox">
           <span>Send Reply: </span>
@@ -113,12 +117,17 @@ const Messaging = ({
 };
 
 Messaging.propTypes = {
+  title: PT.string,
   messages: PT.array.isRequired,
   toggleMessagingView: PT.func,
   sendMessage: PT.func.isRequired,
   updateMessage: PT.func.isRequired,
   currentMessage: PT.string.isRequired,
   hideNav: PT.bool,
+};
+
+Messaging.defaultProps = {
+  title: typeText[eventTypes.PUBLIC_HOLIDAY],
 };
 
 export default container(Messaging);

--- a/src/components/NewBookingModal/index.js
+++ b/src/components/NewBookingModal/index.js
@@ -47,6 +47,7 @@ const BookingModal = props => {
           <Messaging
             toggleMessagingView={toggleMessagingView}
             eventId={selectedBooking.eventId}
+            title={selectedBooking.eventType.description}
           />
         ) : (
           renderBookingForm()


### PR DESCRIPTION
## Relevant Issues

https://trello.com/c/eXAtVLT4/32-working-from-home-modal-window-displaying-holiday-message-label

## Major Changes Made

* Passed in eventType description from bookingModal to be used as a Title in messaging modal 
* Added prop title to messages modal and added default prop values for title so that 'Public Holiday Messages' is always default.

## AC List

Working from home modal window displaying "Holiday Message" label

Steps to reproduce:

- Add a working from home entry onto the booking dashboard
- Select the working from home entry
  Modal appears as expected
- Click the message icon
  Bug: Label reads "Holiday message"

Expected results:

- Add a working from home entry onto the booking dashboard
- Select the working from home entry
  Modal appears as expected
- Click the message icon
  Label reads something else - "Working from home message"
