### PR TITLE
Added a confirmation prompt before deleting an event can be fired

### DIFF
--- a/src/components/NewBookingModal/UpdateBooking/container.js
+++ b/src/components/NewBookingModal/UpdateBooking/container.js
@@ -7,6 +7,7 @@ import Swal from 'sweetalert2';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getUserId } from '../../../reducers';
+import { theme } from './../../../styled';
 
 const Container = Wrapped =>
   class extends React.Component {
@@ -74,18 +75,31 @@ const Container = Wrapped =>
         selectedBooking: { eventId },
       } = this.props;
       const { refreshCalendar, toggleModal } = this.props;
-      cancelEvent(eventId)
-        .then(() => {
-          refreshCalendar();
-          toggleModal(false);
-        })
-        .catch(error =>
-          Swal({
-            title: 'Could not cancel holiday',
-            text: error.message,
-            type: 'error',
-          })
-        );
+      Swal({
+        title: 'Cancel Booking',
+        text: 'Are you sure you wish to cancel this booking?',
+        type: 'question',
+        showCancelButton: true,
+        confirmButtonText: 'Yes',
+        confirmButtonColor: theme.colours.unoBlue,
+        cancelButtonText: 'No',
+      }).then(deleteBooking => {
+        if (deleteBooking.value === true) {
+          cancelEvent(eventId)
+            .then(() => {
+              refreshCalendar();
+              toggleModal(false);
+            })
+            .catch(error =>
+              Swal({
+                title: 'Could not cancel holiday',
+                text: error.message,
+                type: 'error',
+              })
+            );
+        }
+      });
+      
     };
 
     render() {


### PR DESCRIPTION
## Relevant Issues

https://trello.com/c/CZoS9phJ/31-no-confirmation-on-cancelling-a-holiday

## Major Changes Made

* Added a confirmation prompt before deleting an event can be fired

Please note that I could not replicate the approve/reject of mandatory holidays in the admin section.

## AC List

* Add a holiday or wfh event
* Open event to view/update
* Click the bin icon
* Event is immediately cancelled

Should we have a yes/no confirmation popup here in case the icon is clicked by accident?

